### PR TITLE
deploying syslog server on a container

### DIFF
--- a/deploy-apps-clusters/deploy-syslog-from-kube
+++ b/deploy-apps-clusters/deploy-syslog-from-kube
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: rsyslog
+  name: rsyslog
+spec:
+  selector:
+    app: rsyslog
+  ports:
+  - name: tcp-syslog
+    port: 514
+    targetPort: 514
+    nodePort: 30514
+    protocol: TCP
+  - name: udp-syslog
+    port: 514
+    targetPort: 514
+    nodePort: 30514
+    protocol: UDP
+  type: NodePort
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: rsyslog
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rsyslog
+  template:
+    metadata:
+      name: rsyslog
+      labels:
+        app: rsyslog
+    spec:
+      containers:
+      - name: rsyslog
+        image: voxxit/rsyslog:latest
+        imagePullPolicy: "Always"
+        ports:
+        - name: incoming-logs
+          containerPort: 514


### PR DESCRIPTION
For logging purposes. If a user doesn't have a server set up that can accept a syslog protocol, then she can spin up a cluster that deploys that syslog server.